### PR TITLE
Travis can only build after we move to .net core, disable.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,0 @@
-language: csharp
-solution: Nin.sln


### PR DESCRIPTION
Travis doesn't run on windows so until we port to .net core we can't build there.